### PR TITLE
removed System.out.print that was causing excessive logging

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2048m

--- a/quarkus-resteasy-2.0/src/main/java/com/newrelic/instrumentation/quarkus/resteasy/Utils.java
+++ b/quarkus-resteasy-2.0/src/main/java/com/newrelic/instrumentation/quarkus/resteasy/Utils.java
@@ -46,7 +46,6 @@ public class Utils {
 	if (method != null & method.length() > 0) {
 	    name += " (" + method + ")";
 	}
-	System.out.println(name);
 	NewRelic.getAgent().getTransaction().setTransactionName(TransactionNamePriority.FRAMEWORK_LOW, false, "Quarkus",
 		"resteasy", name);
 

--- a/quarkus-resteasy-2.11/src/main/java/com/newrelic/instrumentation/quarkus/resteasy/Utils.java
+++ b/quarkus-resteasy-2.11/src/main/java/com/newrelic/instrumentation/quarkus/resteasy/Utils.java
@@ -39,7 +39,6 @@ public class Utils {
 	if (method != null & method.length() > 0) {
 	    name += " (" + method + ")";
 	}
-	System.out.println(name);
 	NewRelic.getAgent().getTransaction().setTransactionName(TransactionNamePriority.FRAMEWORK_LOW, false, "Quarkus",
 		"resteasy", name);
 

--- a/quarkus-resteasy-2.14.1/src/main/java/com/newrelic/instrumentation/quarkus/resteasy/Utils.java
+++ b/quarkus-resteasy-2.14.1/src/main/java/com/newrelic/instrumentation/quarkus/resteasy/Utils.java
@@ -39,7 +39,6 @@ public class Utils {
 	if (method != null & method.length() > 0) {
 	    name += " (" + method + ")";
 	}
-	System.out.println(name);
 	NewRelic.getAgent().getTransaction().setTransactionName(TransactionNamePriority.FRAMEWORK_LOW, false, "Quarkus",
 		"resteasy", name);
 

--- a/quarkus-resteasy-reactive-2.0/src/main/java/com/newrelic/instrumentation/quarkus/resteasy/reactive/Utils.java
+++ b/quarkus-resteasy-reactive-2.0/src/main/java/com/newrelic/instrumentation/quarkus/resteasy/reactive/Utils.java
@@ -46,7 +46,6 @@ public class Utils {
 	if (method != null & method.length() > 0) {
 	    name += " (" + method + ")";
 	}
-	System.out.println(name);
 	NewRelic.getAgent().getTransaction().setTransactionName(TransactionNamePriority.FRAMEWORK_LOW, false, "Quarkus",
 		"resteasy-reactive", name);
 

--- a/quarkus-resteasy-reactive-2.11/src/main/java/com/newrelic/instrumentation/quarkus/resteasy/reactive/Utils.java
+++ b/quarkus-resteasy-reactive-2.11/src/main/java/com/newrelic/instrumentation/quarkus/resteasy/reactive/Utils.java
@@ -123,7 +123,6 @@ public class Utils {
 	if (method != null & method.length() > 0) {
 	    name += " (" + method + ")";
 	}
-	// System.out.println(name);
 	NewRelic.getAgent().getTransaction().setTransactionName(TransactionNamePriority.FRAMEWORK_LOW, false, "Quarkus",
 		"resteasy-reactive", name);
 

--- a/quarkus-resteasy-reactive-2.6/src/main/java/com/newrelic/instrumentation/quarkus/resteasy/reactive/Utils.java
+++ b/quarkus-resteasy-reactive-2.6/src/main/java/com/newrelic/instrumentation/quarkus/resteasy/reactive/Utils.java
@@ -123,7 +123,6 @@ public class Utils {
 	if (method != null & method.length() > 0) {
 	    name += " (" + method + ")";
 	}
-	// System.out.println(name);
 	NewRelic.getAgent().getTransaction().setTransactionName(TransactionNamePriority.FRAMEWORK_LOW, false, "Quarkus",
 		"resteasy-reactive", name);
 

--- a/quarkus-resteasy-reactive-3.0/src/main/java/com/newrelic/instrumentation/quarkus/resteasy/reactive/Utils.java
+++ b/quarkus-resteasy-reactive-3.0/src/main/java/com/newrelic/instrumentation/quarkus/resteasy/reactive/Utils.java
@@ -122,7 +122,6 @@ public class Utils {
 	if (method != null & method.length() > 0) {
 	    name += " (" + method + ")";
 	}
-	// System.out.println(name);
 	NewRelic.getAgent().getTransaction().setTransactionName(TransactionNamePriority.FRAMEWORK_LOW, false, "Quarkus",
 		"resteasy-reactive", name);
 

--- a/quarkus-resteasy-reactive-3.9/src/main/java/com/newrelic/instrumentation/quarkus/resteasy/reactive/Utils.java
+++ b/quarkus-resteasy-reactive-3.9/src/main/java/com/newrelic/instrumentation/quarkus/resteasy/reactive/Utils.java
@@ -122,7 +122,6 @@ public class Utils {
 	if (method != null & method.length() > 0) {
 	    name += " (" + method + ")";
 	}
-	// System.out.println(name);
 	NewRelic.getAgent().getTransaction().setTransactionName(TransactionNamePriority.FRAMEWORK_LOW, false, "Quarkus",
 		"resteasy-reactive", name);
 


### PR DESCRIPTION
Several Java classes contained a System.out.println that was leading to excessive logging in the customer application logs.